### PR TITLE
[W02] Add test for the case when to and from of the returned interval are the same indices

### DIFF
--- a/w02/test/gad/binarysearch/IntervalSearchTest.java
+++ b/w02/test/gad/binarysearch/IntervalSearchTest.java
@@ -29,9 +29,9 @@ class IntervalSearchTest {
 						Interval.NonEmptyInterval.fromArrayIndices(3, 9),
 						Interval.fromArrayIndices(1, 8)),
 				Arguments.of(
-                        new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8, 10, 23},
-                        Interval.NonEmptyInterval.fromArrayIndices(8, 8),
-                        Interval.fromArrayIndices(8, 8))
+						new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8, 10, 23},
+						Interval.NonEmptyInterval.fromArrayIndices(8, 8),
+						Interval.fromArrayIndices(8, 8))
 		);
 	}
 

--- a/w02/test/gad/binarysearch/IntervalSearchTest.java
+++ b/w02/test/gad/binarysearch/IntervalSearchTest.java
@@ -27,7 +27,11 @@ class IntervalSearchTest {
 				Arguments.of(
 						new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8, 10, 23},
 						Interval.NonEmptyInterval.fromArrayIndices(3, 9),
-						Interval.fromArrayIndices(1, 8))
+						Interval.fromArrayIndices(1, 8)),
+				Arguments.of(
+                        new int[]{1, 4, 4, 4, 5, 5, 5, 5, 8, 10, 23},
+                        Interval.NonEmptyInterval.fromArrayIndices(8, 8),
+                        Interval.fromArrayIndices(8, 8))
 		);
 	}
 


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I locally pass **all** tests or calculated manually the correct solutions on paper.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://github.com/JohannesStoehr/gad23-tests/blob/main/CONTRIBUTING.md).
- [x] The newly added tests do not reveal the solutions dynamically calculating the solutions as expected in the exercise.

### Description

I passed all local but not all Artemis tests. This was because I forgot the case where `from` and `to` of the returned interval are the same number. The added test catches this edge case.

### Review Progress
<!-- Each Pull Request should be reviewed by at least one other student. -->
<!-- The code and the functionality (= running the tests locally) need to be reviewed -->
<!-- The reviewer or author check the following boxes. -->

#### Review
- [ ] Review 1
- [ ] Optional Review 2