### PR TITLE
[W04] fix `ModuloHelper` implementation

### DIFF
--- a/w04/test/gad/simplehash/FindFindAllTest.java
+++ b/w04/test/gad/simplehash/FindFindAllTest.java
@@ -47,12 +47,7 @@ public class FindFindAllTest {
             throws Exception {
         Hashtable<String, String> hashtable = new Hashtable<>(minSize, a);
 
-        ModuloHelper mH = new ModuloHelper() {
-            @Override
-            public int doTheMagic(int i, int divisor) {
-                return Hashtable.fastModulo(i, divisor);
-            }
-        };
+        ModuloHelper mH = (i, divisor) -> i % divisor;
 
         Field tableField = hashtable.getClass().getDeclaredField("table");
         tableField.setAccessible(true);
@@ -120,12 +115,7 @@ public class FindFindAllTest {
             throws Exception {
         Hashtable<String, String> hashtable = new Hashtable<>(minSize, a);
 
-        ModuloHelper mH = new ModuloHelper() {
-            @Override
-            public int doTheMagic(int i, int divisor) {
-                return Hashtable.fastModulo(i, divisor);
-            }
-        };
+        ModuloHelper mH = (i, divisor) -> i % divisor;
 
         Field tableField = hashtable.getClass().getDeclaredField("table");
         tableField.setAccessible(true);

--- a/w04/test/gad/simplehash/HashTest.java
+++ b/w04/test/gad/simplehash/HashTest.java
@@ -36,12 +36,7 @@ public class HashTest {
     public void testHash(int minSize, int[] a, String k, int expect) {
         Hashtable<String, Integer> hashtable = new Hashtable<>(minSize, a);
 
-        ModuloHelper mH = new ModuloHelper() {
-            @Override
-            public int doTheMagic(int i, int divisor) {
-                return Hashtable.fastModulo(i, divisor);
-            }
-        };
+        ModuloHelper mH = (i, divisor) -> i % divisor;
 
         assertEquals(expect, hashtable.h(k, mH));
     }

--- a/w04/test/gad/simplehash/InsertRemoveTest.java
+++ b/w04/test/gad/simplehash/InsertRemoveTest.java
@@ -40,12 +40,7 @@ public class InsertRemoveTest {
     public void testInsert(int minSize, int[] a, String[] k, String[] v, List<Pair<String, String>>[] expect) {
         Hashtable<String, String> hashtable = new Hashtable<>(minSize, a);
 
-        ModuloHelper mH = new ModuloHelper() {
-            @Override
-            public int doTheMagic(int i, int divisor) {
-                return Hashtable.fastModulo(i, divisor);
-            }
-        };
+        ModuloHelper mH = (i, divisor) -> i % divisor;
 
         for (int i = 0; i < k.length; i++) {
             hashtable.insert(k[i], v[i], mH);
@@ -89,12 +84,7 @@ public class InsertRemoveTest {
                            List<Pair<String, String>>[] after) throws Exception {
         Hashtable<String, String> hashtable = new Hashtable<>(minSize, a);
 
-        ModuloHelper mH = new ModuloHelper() {
-            @Override
-            public int doTheMagic(int i, int divisor) {
-                return Hashtable.fastModulo(i, divisor);
-            }
-        };
+        ModuloHelper mH = (i, divisor) -> i % divisor;
 
         Field tableField = hashtable.getClass().getDeclaredField("table");
         tableField.setAccessible(true);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I confirm that my tests, if any, are correct
    - [x] Optional: I pass **all** artemis tests.
    - [x] Optional: I pass **all** tests, that are added in this PR.
    - [ ] Optional: I calculated manually the correct solutions on paper.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://github.com/JohannesStoehr/gad23-tests/blob/main/CONTRIBUTING.md).
- [x] The newly added tests do not reveal the solutions dynamically calculating the solutions as expected in the exercise.
- [ ] Other students approved this Pull Request.

### Description
<!-- Describe your changes shortly -->

General `HashTable` test should not depend on correct `fastModulo` implementation therefore ModuloHelper should use `%` operator instead of custom implementaition.