### PR TITLE
[W04] add testcases where `key1.equals(key2)` but `key1 != key2`

### DIFF
--- a/w04/test/gad/simplehash/FindFindAllTest.java
+++ b/w04/test/gad/simplehash/FindFindAllTest.java
@@ -35,6 +35,13 @@ public class FindFindAllTest {
                         add(new Pair<>("x", "foo"));
                         add(new Pair<>("y", "bar"));
                     }
+                }}, "bar"),
+
+                Arguments.of(1, new int[]{1}, new String("y"), new List[]{new ArrayList<Pair<String, String>>() {
+                    {
+                        add(new Pair<>("x", "foo"));
+                        add(new Pair<>("y", "bar"));
+                    }
                 }}, "bar")
 
         );
@@ -103,6 +110,14 @@ public class FindFindAllTest {
                     }
                 }}, new String[]{"foo", "bar"}),
                 Arguments.of(1, new int[]{1}, "x", new List[]{new ArrayList<Pair<String, String>>() {
+                    {
+                        add(new Pair<>("x", "foo"));
+                        add(new Pair<>("x", "bar"));
+                        add(new Pair<>("y", "baz"));
+                    }
+                }}, new String[]{"foo", "bar"}),
+
+                Arguments.of(1, new int[]{1}, new String("x"), new List[]{new ArrayList<Pair<String, String>>() {
                     {
                         add(new Pair<>("x", "foo"));
                         add(new Pair<>("x", "bar"));

--- a/w04/test/gad/simplehash/InsertRemoveTest.java
+++ b/w04/test/gad/simplehash/InsertRemoveTest.java
@@ -79,8 +79,18 @@ public class InsertRemoveTest {
                     {
                         add(new Pair<>("y", "bar"));
                     }
-                }}));
-
+                }}),
+                Arguments.of(1, new int[]{1}, new String("x"), true, new List[]{new ArrayList<Pair<String, String>>() {
+                    {
+                        add(new Pair<>("x", "foo"));
+                        add(new Pair<>("y", "bar"));
+                    }
+                }}, new List[]{new ArrayList<Pair<String, String>>() {
+                    {
+                        add(new Pair<>("y", "bar"));
+                    }
+                }})
+        );
     }
 
     @ParameterizedTest


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I confirm that my tests, if any, are correct
    - [x] Optional: I pass **all** artemis tests.
    - [x] Optional: I pass **all** tests, that are added in this PR.
    - [ ] Optional: I calculated manually the correct solutions on paper.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://github.com/JohannesStoehr/gad23-tests/blob/main/CONTRIBUTING.md).
- [x] The newly added tests do not reveal the solutions dynamically calculating the solutions as expected in the exercise.
- [ ] Other students approved this Pull Request.

### Description
<!-- Describe your changes shortly -->

Keys that are equal but not the same object should be treated correctly. e.g. Interned Strings...