### PR TITLE
[W06] Add last year's tests and Artemis Example for MedianPivotFrontTest and Tests fot MidPivotTest

### DIFF
--- a/w06/test/gad.bettersorting/DistributedMedianPivotTest.java
+++ b/w06/test/gad.bettersorting/DistributedMedianPivotTest.java
@@ -1,0 +1,136 @@
+package gad.bettersorting;
+
+import gad.simplesort.PivotFinder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DistributedMedianPivotTest {
+
+    @ParameterizedTest
+    @MethodSource({"artemisExample", "fromEquals0", "allParameterDiffer"})
+    void distributedMedianPivotTest(int[] numbers, int expected, int numberOfConsideredElements, int from, int to) {
+        PivotFinder medianPivotFinder = PivotFinder.getMedianPivotDistributed(numberOfConsideredElements);
+        assertEquals(expected, medianPivotFinder.findPivot(numbers, from, to));
+    }
+
+    private static Stream<Arguments> artemisExample() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+                        4,
+                        3,
+                        0,
+                        9
+                ),
+                Arguments.of(
+                        new int[]{9, 1, 8, 5, 2, 3, 5, 1, 0, 7},
+                        6,
+                        5,
+                        0,
+                        9
+                ),
+                Arguments.of(
+                        new int[]{9, 1, 8, 5, 2, 3, 5, 1, 0, 7},
+                        5,
+                        5,
+                        1,
+                        9
+                )
+        );
+    }
+
+    private static Stream<Arguments> fromEquals0() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{1, 5, 5, 5, 5, 5, 5, 7, 8},
+                        0,
+                        2,
+                        0,
+                        8
+                ),
+                Arguments.of(
+                        new int[]{1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 9},
+                        5,
+                        4,
+                        0,
+                        15
+                ),
+                Arguments.of(
+                        new int[]{1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 9},
+                        6,
+                        5,
+                        0,
+                        15
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10},
+                        0,
+                        3,
+                        0,
+                        4
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        6,
+                        7,
+                        0,
+                        12
+                ),
+                Arguments.of(
+                        new int[]{44, 23, 2, 4, 1, 99, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        14,
+                        3,
+                        0,
+                        14
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 23, 18, 28, 6, 14, 16, 19, 0, 3, 5, 7, 27, 8, 9, 20, 24},
+                        15,
+                        3,
+                        0,
+                        30
+                )
+        );
+    }
+
+    private static Stream<Arguments> allParameterDiffer() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{44, 23, 2, 4, 1, 99, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        6,
+                        6,
+                        2,
+                        12
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12,
+                                10, 17, 22, 25, 24, 18, 28, 6, 14, 16,
+                                19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        26,
+                        4,
+                        20,
+                        30
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10},
+                        1,
+                        2,
+                        1,
+                        3
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        1,
+                        2,
+                        1,
+                        11
+                )
+        );
+    }
+}

--- a/w06/test/gad.bettersorting/DoubleDistributedMedianPivotTest.java
+++ b/w06/test/gad.bettersorting/DoubleDistributedMedianPivotTest.java
@@ -1,0 +1,118 @@
+package gad.bettersorting;
+
+import gad.simplesort.DualPivotFinder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DoubleDistributedMedianPivotTest {
+    @ParameterizedTest
+    @MethodSource({"noParameterDeviating", "numbersOfConsideredElementsDeviating", "deviatingFromAndTo", "allParameterDiffer"})
+    void doubleDistributedMedianPivotTest(int[] numbers, int[] expected, int numbersOfConsideredElements, int from, int to) {
+        DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(numbersOfConsideredElements);
+        assertArrayEquals(expected, dualPivotFinder.findPivot(numbers, from, to));
+    }
+
+    private static Stream<Arguments> noParameterDeviating() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11},
+                        new int[]{0, 6},
+                        12,
+                        0,
+                        11
+                )
+        );
+    }
+
+    private static Stream<Arguments> numbersOfConsideredElementsDeviating() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{4, 9, 1, 10, 2},
+                        new int[]{2, 4},
+                        3,
+                        0,
+                        4
+                ),
+                Arguments.of(
+                        new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11},
+                        new int[]{0, 10},
+                        3,
+                        0,
+                        11
+                ),
+                Arguments.of(
+                        new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11},
+                        new int[]{4, 6},
+                        5,
+                        0,
+                        11
+                ),
+                Arguments.of(
+                        new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11},
+                        new int[]{0, 6},
+                        4,
+                        0,
+                        11
+                )
+        );
+    }
+
+    private static Stream<Arguments> deviatingFromAndTo() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 12, 9, 6, 3, 0},
+                        new int[]{4, 8},
+                        21,
+                        0,
+                        11
+                ),
+                Arguments.of(
+                        new int[]{5, 6, 5, 6, 55, 6, 5, 6, 55, 6, 5, 6, 5},
+                        new int[]{4, 5},
+                        13,
+                        4,
+                        8
+                ),
+                Arguments.of(
+                        new int[]{5, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 5},
+                        new int[]{2, 3},
+                        25,
+                        2,
+                        18
+                )
+        );
+    }
+
+    private static Stream<Arguments> allParameterDiffer() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 12, 9, 6, 3, 0},
+                        new int[]{2, 6},
+                        5,
+                        0,
+                        11
+                ),
+                Arguments.of(
+                        new int[]{30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 12, 9, 6, 3, 0},
+                        new int[]{14, 18},
+                        5,
+                        12,
+                        21
+                ),
+                Arguments.of(
+                        new int[]{5, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 5},
+                        new int[]{2, 4},
+                        8,
+                        2,
+                        18
+                )
+        );
+    }
+}

--- a/w06/test/gad.bettersorting/DoubleMedianPivotTest.java
+++ b/w06/test/gad.bettersorting/DoubleMedianPivotTest.java
@@ -1,0 +1,220 @@
+package gad.bettersorting;
+
+import gad.simplesort.DualPivotFinder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DoubleMedianPivotTest {
+
+    @ParameterizedTest
+    @MethodSource({"normalAllElements", "deviatingNumbersOfConsideredElements", "noParameterDeviating", "deviatingFromAndTo", "allParameterDiffer", "hard"})
+    void doubleMedianPivotTest(int[] numbers, int[] expected, int numbersOfConsideredElements, int from, int to) {
+        DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbersOfConsideredElements);
+        assertArrayEquals(expected, dualPivotFinder.findPivot(numbers, from, to));
+    }
+
+    private static Stream<Arguments> normalAllElements() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{4, 9, 1, 10, 2, 5, 99, 23, 3, 35, 6},
+                        new int[]{0, 3},
+                        11,
+                        0,
+                        10
+                ),
+                Arguments.of(
+                        new int[]{8, 42, 10, 75, 29, 77, 38, 57, 24},
+                        new int[]{1, 8},
+                        9,
+                        0,
+                        8
+                ),
+                Arguments.of(
+                        new int[]{24, 8, 76, 10, 75, 29, 77, 38, 57},
+                        new int[]{0, 8},
+                        9,
+                        0,
+                        8
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{27, 28},
+                        31,
+                        0,
+                        30
+                ),
+                Arguments.of(
+                        new int[]{5, 6, 5, 6, 55, 6, 5, 6, 55, 6, 5, 6, 5},
+                        new int[]{0, 1},
+                        13,
+                        0,
+                        12
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 8, 8, 8, 12, 14, 26, 26, 28, 30, 30, 30, 30, 34, 36, 36},
+                        new int[]{5, 10},
+                        17,
+                        0,
+                        16
+                ),
+                Arguments.of(
+                        new int[]{5, 6, 7, 44, 44, 44, 44, 44, 44, 44, 44},
+                        new int[]{3, 4},
+                        11,
+                        0,
+                        10
+                ),
+                Arguments.of(
+                        new int[]{16, 15, 14, 12, 12, 12, 11, 10, 10, 10, 10, 4, 2},
+                        new int[]{3, 7},
+                        13,
+                        0,
+                        12
+                ),
+                Arguments.of(
+                        new int[]{16, 15, 14, 12, 12, 12, 10, 10, 10, 10, 4, 2},
+                        new int[]{3, 6},
+                        12,
+                        0,
+                        11
+                ),
+                Arguments.of(
+                        new int[]{10, 10, 10, 15, 10, 20, 10, 10},
+                        new int[]{0, 1},
+                        8,
+                        0,
+                        7
+                )
+        );
+    }
+
+    private static Stream<Arguments> deviatingNumbersOfConsideredElements() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{4, 9, 1, 10, 2},
+                        new int[]{1, 4},
+                        5,
+                        0,
+                        4
+                ),
+                Arguments.of(
+                        new int[]{4, 9, 1, 10, 2, 5, 99, 23, 3, 35, 6},
+                        new int[]{1, 2},
+                        5,
+                        1,
+                        4
+                ),
+                Arguments.of(
+                        new int[]{4, 9, 1, 10, 2},
+                        new int[]{1, 4},
+                        5,
+                        0,
+                        4
+                ),
+                Arguments.of(
+                        new int[]{4, 9, 1, 10, 2},
+                        new int[]{1, 4},
+                        5,
+                        0,
+                        4
+                )
+        );
+    }
+
+    private static Stream<Arguments> noParameterDeviating() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+                        new int[]{0, 1},
+                        10,
+                        0,
+                        9
+                )
+        );
+    }
+
+    private static Stream<Arguments> deviatingFromAndTo() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{1, 3},
+                        31,
+                        0,
+                        9
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{0, 1},
+                        31,
+                        0,
+                        2
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{10, 15},
+                        31,
+                        5,
+                        15
+                )
+        );
+    }
+
+    private static Stream<Arguments> allParameterDiffer() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{3, 4},
+                        6,
+                        2,
+                        30
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{4, 8},
+                        7,
+                        4,
+                        30
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{10, 13},
+                        8,
+                        6,
+                        30
+                )
+        );
+    }
+
+    /**
+     * <div>
+     *     This Testcase is a bitch. It's nearly impossible to pass it.
+     * </div>
+     * <div>
+     *     Kudos to you if you can pass this testcase. It took me all night getting the algorithm right.
+     * </div>
+     */
+    private static Stream<Arguments> hard() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55},
+                        new int[]{0, 1},
+                        17,
+                        0,
+                        16
+                ),
+                Arguments.of(
+                        new int[]{44, 44, 44, 5, 6, 44, 44, 7, 44, 44, 44},
+                        new int[]{0, 1},
+                        11,
+                        0,
+                        10
+                )
+        );
+    }
+}

--- a/w06/test/gad.bettersorting/MedianPivotFrontTest.java
+++ b/w06/test/gad.bettersorting/MedianPivotFrontTest.java
@@ -1,0 +1,48 @@
+package gad.bettersorting;
+
+import gad.simplesort.PivotFinder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MedianPivotFrontTest {
+
+    private static Stream<Arguments> artemisExampleTest()
+    {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+                        0,
+                        9,
+                        3,
+                        1
+                ),
+                Arguments.of(
+                        new int[]{9, 1, 8, 5, 2, 3, 5, 1, 0, 7},
+                        0,
+                        9,
+                        5,
+                        3
+                ),
+                Arguments.of(
+                        new int[]{9, 1, 8, 5, 2, 3, 5, 1, 0, 7},
+                        2,
+                        8,
+                        5,
+                        3
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void artemisExampleTest(int[] numbers, int from, int to, int numbersOfConsideredElements, int expected)
+    {
+        int actual = PivotFinder.getMedianPivotFront(numbersOfConsideredElements).findPivot(numbers,from,to);
+        assertEquals(expected,actual);
+    }
+}

--- a/w06/test/gad.bettersorting/MedianPivotTest.java
+++ b/w06/test/gad.bettersorting/MedianPivotTest.java
@@ -1,0 +1,220 @@
+package gad.bettersorting;
+
+import gad.simplesort.PivotFinder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MedianPivotTest {
+
+    @ParameterizedTest
+    @MethodSource({"artemisBeispiele", "numberOfConsideredElementsEqualToLength", "numberOfConsideredElementsSmaller", "numberOfConsideredElementsBigger", "deviatingFromAndTo"})
+    void medianPivotTest(int[] numbers, int expected, int numberOfConsideredElements, int from, int to) {
+        PivotFinder medianPivotFinder = PivotFinder.getMedianPivotFront(numberOfConsideredElements);
+        assertEquals(expected, medianPivotFinder.findPivot(numbers, from, to));
+    }
+
+    private static Stream<Arguments> artemisBeispiele() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+                        1,
+                        3,
+                        0,
+                        9
+                ),
+                Arguments.of(
+                        new int[]{9, 1, 8, 5, 2, 3, 5, 1, 0, 7},
+                        3,
+                        5,
+                        0,
+                        9
+                ),
+                Arguments.of(
+                        new int[]{9, 1, 8, 5, 2, 3, 5, 1, 0, 7},
+                        3,
+                        5,
+                        2,
+                        8
+                )
+        );
+    }
+
+    private static Stream<Arguments> numberOfConsideredElementsEqualToLength() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{1, 5, 5, 5, 5, 5, 5, 7, 8},
+                        1,
+                        9,
+                        0,
+                        8
+                ),
+                Arguments.of(
+                        new int[]{1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 9},
+                        5,
+                        16,
+                        0,
+                        15
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10},
+                        1,
+                        5,
+                        0,
+                        4
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        6,
+                        13,
+                        0,
+                        12
+                ),
+                Arguments.of(
+                        new int[]{44, 23, 2, 4, 1, 99, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        10,
+                        16,
+                        0,
+                        15
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        4,
+                        31,
+                        0,
+                        30
+                )
+        );
+    }
+
+    private static Stream<Arguments> numberOfConsideredElementsSmaller() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10},
+                        0,
+                        3,
+                        0,
+                        5
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        1,
+                        5,
+                        0,
+                        12
+                ),
+                Arguments.of(
+                        new int[]{44, 23, 2, 4, 1, 99, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        6,
+                        7,
+                        0,
+                        15
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        10,
+                        12,
+                        0,
+                        30
+                ),
+                Arguments.of(
+                        new int[]{44, 23, 2, 4, 1, 99, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        0,
+                        16 + Integer.MAX_VALUE,
+                        0,
+                        15
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        0,
+                        -31,
+                        0,
+                        30
+                )
+        );
+    }
+
+    private static Stream<Arguments> numberOfConsideredElementsBigger() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10},
+                        1,
+                        6,
+                        0,
+                        4
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        6,
+                        14,
+                        0,
+                        12
+                )
+        );
+    }
+
+    private static Stream<Arguments> deviatingFromAndTo() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10},
+                        0,
+                        5,
+                        0,
+                        3
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        5,
+                        13,
+                        0,
+                        10
+                ),
+                Arguments.of(
+                        new int[]{44, 23, 2, 4, 1, 99, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        10,
+                        17,
+                        0,
+                        17
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        19,
+                        31,
+                        3,
+                        30
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10},
+                        1,
+                        5,
+                        1,
+                        3
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        11,
+                        13,
+                        10,
+                        12
+                ),
+                Arguments.of(
+                        new int[]{44, 23, 2, 4, 1, 99, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        7,
+                        5,
+                        4,
+                        12
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        16,
+                        8,
+                        9,
+                        23
+                )
+        );
+    }
+}

--- a/w06/test/gad.bettersorting/MergesortTest.java
+++ b/w06/test/gad.bettersorting/MergesortTest.java
@@ -1,0 +1,71 @@
+package gad.bettersorting;
+
+import gad.simplesort.Mergesort;
+import gad.simplesort.StudentResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MergesortTest {
+
+    private static Stream<Arguments> mergeSortTest() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10},
+                        new int[]{1, 2, 4, 9, 10}
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        new int[]{1, 2, 4, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45}
+                ),
+                Arguments.of(
+                        new int[]{44, 23, 2, 4, 1, 99, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        new int[]{1, 2, 4, 9, 10, 11, 12, 13, 14, 15, 23, 26, 37, 44, 45, 99}
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30}
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30}
+                ),
+                Arguments.of(
+                        new int[]{5, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 5},
+                        new int[]{5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 55, 55, 55}
+                ),
+                Arguments.of(
+                        new int[]{30, 25, 20, 15, 14, 10, 5, 1, 0, -5, -20, -100},
+                        new int[]{-100, -20, -5, 0, 1, 5, 10, 14, 15, 20, 25, 30}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void mergeSortTest(int[] numbers, int[] expected) {
+        Mergesort mergesort = new Mergesort(5);
+        StudentResult result = new StudentResult();
+
+        mergesort.sort(numbers, result, 0, numbers.length - 1);
+        assertArrayEquals(expected, numbers);
+
+    }
+
+    @Test
+    void mergeSortCompilerTest() {
+        Mergesort mergesort = new Mergesort(0);
+        StudentResult studentResult = new StudentResult();
+        // Tests for public access and correctness of parameters
+        // This is a compiler-test, your compiler will tell you
+        // if there's something wrong with your code before you can even run the test
+        mergesort.sort(new int[]{1}, studentResult);
+        mergesort.sort(new int[]{1}, studentResult, 0, 0);
+        mergesort.sort(new int[]{1}, studentResult, 0, 0, new int[]{1, 2});
+    }
+}

--- a/w06/test/gad.bettersorting/MidPivotTest.java
+++ b/w06/test/gad.bettersorting/MidPivotTest.java
@@ -1,0 +1,43 @@
+package gad.bettersorting;
+
+import gad.simplesort.PivotFinder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MidPivotTest {
+
+    private static Stream<Arguments> midPivotTest() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{0, 1, 2, 3, 4},
+                        0,
+                        4,
+                        2
+                ),
+                Arguments.of(
+                        new int[]{0, 1, 2, 3},
+                        0,
+                        3,
+                        1
+                ),
+                Arguments.of(
+                        new int[]{0, 1, 2, 3},
+                        1,
+                        3,
+                        2
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void midPivotTest(int[] numbers, int from, int to, int expected) {
+        int actual = PivotFinder.getMidPivot().findPivot(numbers, from, to);
+        assertEquals(expected, actual);
+    }
+}

--- a/w06/test/gad.bettersorting/QuicksortTest.java
+++ b/w06/test/gad.bettersorting/QuicksortTest.java
@@ -1,0 +1,58 @@
+package gad.bettersorting;
+
+import gad.simplesort.PivotFinder;
+import gad.simplesort.Quicksort;
+import gad.simplesort.StudentResult;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class QuicksortTest {
+
+    private static Stream<Arguments> quickSortTest() {
+        return Stream.of(
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10},
+                        new int[]{1, 2, 4, 9, 10}
+                ),
+                Arguments.of(
+                        new int[]{2, 4, 1, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        new int[]{1, 2, 4, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45}
+                ),
+                Arguments.of(
+                        new int[]{44, 23, 2, 4, 1, 99, 9, 10, 11, 12, 13, 14, 15, 26, 37, 45},
+                        new int[]{1, 2, 4, 9, 10, 11, 12, 13, 14, 15, 23, 26, 37, 44, 45, 99}
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30}
+                ),
+                Arguments.of(
+                        new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0},
+                        new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30}
+                ),
+                Arguments.of(
+                        new int[]{5, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 5},
+                        new int[]{5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 55, 55, 55}
+                ),
+                Arguments.of(
+                        new int[]{30, 25, 20, 15, 14, 10, 5, 1, 0, -5, -20, -100},
+                        new int[]{-100, -20, -5, 0, 1, 5, 10, 14, 15, 20, 25, 30}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void quickSortTest(int[] numbers, int[] expected) {
+        Quicksort quicksort = new Quicksort(PivotFinder.getLastPivot(), 5);
+        StudentResult result = new StudentResult();
+
+        quicksort.sort(numbers, result, 0, numbers.length - 1);
+        assertArrayEquals(expected, numbers);
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I confirm that my tests, if any, are correct
    - [x] Optional: I pass **all** artemis tests.
    - [x] Optional: I pass **all** tests, that are added in this PR.
    - [x] Optional: I calculated manually the correct solutions on paper.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://github.com/JohannesStoehr/gad23-tests/blob/main/CONTRIBUTING.md).
- [x] The newly added tests do not reveal the solutions dynamically calculating the solutions as expected in the exercise.
- [ ] Other students approved this Pull Request.

### Description
<!-- Describe your changes shortly -->
- I have updated all tests from last year to `ParameterizedTest`
- In the class `MedianPivotFrontTest`, I added the examples from artemis 
- in the class `MidPivotTest`, I added personaly new tests by my own