### PR TITLE
[W07] Adding last year tests and tests in RadixSortTest and BinaryRadixSortTest

### DIFF
--- a/w07/test/gad/radixsort/BinaryRadixSortTest.java
+++ b/w07/test/gad/radixsort/BinaryRadixSortTest.java
@@ -1,0 +1,124 @@
+package gad.radixsort;
+
+import gad.radix.BinaryBucket;
+import gad.radix.BinaryRadixSort;
+import gad.radix.StudentResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BinaryRadixSortTest {
+
+
+    @ParameterizedTest
+    @MethodSource("provideTestDataBinaryKey")
+    @DisplayName("Binary Key")
+    @Order(1)
+    void testBinaryKey(int element, int binPlace, int expected) {
+        assertEquals(expected, BinaryRadixSort.key(element, binPlace));
+    }
+
+    private static Stream<Arguments> provideTestDataBinaryKey() {
+        return Stream.of(
+                Arguments.of(0b00000000000000000000000000000001, 0, 1),
+                Arguments.of(0b00000000000000000000010000000010, 1, 1),
+                Arguments.of(0b00000000000000000000010000000100, 2, 1),
+                Arguments.of(0b10000000000000000000000000000001, 31, 1),
+                Arguments.of(0b01000000000000000000000000000000, 30, 1),
+                Arguments.of(0b1111011111111111111111111111111, 26, 0),
+                Arguments.of(0b00000000000000000000010000000000, 10, 1)
+        );
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("Binary Bucket")
+    void testBinaryBucket() {
+        BinaryBucket binaryBucket = new BinaryBucket(10);
+        binaryBucket.insertLeft(2);
+        binaryBucket.insertLeft(5);
+        binaryBucket.insertRight(10);
+        assertEquals(2, binaryBucket.getMid());
+        binaryBucket = new BinaryBucket(100);
+        for (int i = 0; i < 99; i++) {
+            binaryBucket.insertLeft(1);
+        }
+        assertEquals(99, binaryBucket.getMid());
+    }
+
+    private void sortTest(int[] elements, int[] expects) {
+        Arrays.sort(expects);
+        BinaryRadixSort.sort(elements, new StudentResult());
+        assertArrayEquals(expects, elements);
+    }
+
+    @Test
+    @DisplayName("Only negativ Numbers as elements")
+    @Order(3)
+    void sortOnlyNegativTest() {
+        Random random = new Random(100);
+        int[] numbers = new int[500];
+        for (int i = 0; i < numbers.length; i++) {
+            numbers[i] = random.nextInt(Integer.MIN_VALUE, -1);
+        }
+        int[] expects = Arrays.copyOf(numbers, numbers.length);
+        sortTest(numbers, expects);
+    }
+
+    @Test
+    @DisplayName("Only positive Numbers as elements")
+    @Order(2)
+    void sortOnlyPositiveTest() {
+        Random random = new Random(100);
+        int[] numbers = new int[500];
+        for (int i = 0; i < numbers.length; i++) {
+            numbers[i] = random.nextInt(0, Integer.MAX_VALUE);
+        }
+        int[] expects = Arrays.copyOf(numbers, numbers.length);
+        sortTest(numbers, expects);
+    }
+
+    @Test
+    @DisplayName("Usual elements")
+    @Order(4)
+    void sortUsualTest() {
+        Random random = new Random(100);
+        int[] numbers = new int[500];
+        for (int i = 0; i < numbers.length; i++) {
+            numbers[i] = random.nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        }
+        int[] expects = Arrays.copyOf(numbers, numbers.length);
+        sortTest(numbers, expects);
+    }
+
+    /**
+     * <div>
+     * This test may not pass on every device.
+     * It also doesn't reflect the requirement of the performance description on Artemis.
+     * The timeout only serves as a barrier if the test should run too long on a device.
+     * I need an average of 1.8 seconds for this test.
+     * </div>
+     */
+    @Test
+    @DisplayName("Big Test")
+    @Order(5)
+    void sortBigTest() {
+        Random random = new Random(100);
+        int[] numbers = new int[250_000];
+        for (int i = 0; i < numbers.length; i++) {
+            numbers[i] = random.nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        }
+        int[] expects = Arrays.copyOf(numbers, numbers.length);
+        assertTimeoutPreemptively(Duration.ofSeconds(2), () -> sortTest(numbers, expects));
+    }
+}

--- a/w07/test/gad/radixsort/BinaryRadixSortTest.java
+++ b/w07/test/gad/radixsort/BinaryRadixSortTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Random;
 import java.util.stream.Stream;
 
+import static gad.radix.BinaryRadixSort.sort;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BinaryRadixSortTest {
@@ -58,7 +59,7 @@ public class BinaryRadixSortTest {
 
     private void sortTest(int[] elements, int[] expects) {
         Arrays.sort(expects);
-        BinaryRadixSort.sort(elements, new StudentResult());
+        sort(elements, new StudentResult());
         assertArrayEquals(expects, elements);
     }
 
@@ -104,9 +105,16 @@ public class BinaryRadixSortTest {
     /**
      * <div>
      * This test may not pass on every device.
-     * It also doesn't reflect the requirement of the performance description on Artemis.
+     * This test is only an indicator whether the sort-Method might be fast enough for Artemis.
+     * There is no logging for this test, because this is slowing down the method.
      * The timeout only serves as a barrier if the test should run too long on a device.
-     * I need an average of 1.8 seconds for this test.
+     * I need an average of 700 milliseconds for this test specification.
+     * <br>
+     * <br>
+     * If you would like to have also logging for this test, you could change from "new int[2_000_000] to new int[250_000]"
+     * and "new StudentResultTest()" to "new StudentResult()".
+     * After this change the test doesn't reflect the requirement of the performance description on Artemis.
+     * I need an average of 1.8 seconds for this test specification.
      * </div>
      */
     @Test
@@ -114,11 +122,13 @@ public class BinaryRadixSortTest {
     @Order(5)
     void sortBigTest() {
         Random random = new Random(100);
-        int[] numbers = new int[250_000];
+        int[] numbers = new int[2_000_000];
         for (int i = 0; i < numbers.length; i++) {
             numbers[i] = random.nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE);
         }
         int[] expects = Arrays.copyOf(numbers, numbers.length);
-        assertTimeoutPreemptively(Duration.ofSeconds(2), () -> sortTest(numbers, expects));
+        Arrays.sort(expects);
+        sort(numbers,new StudentResultTest());
+        assertTimeoutPreemptively(Duration.ofSeconds(2), () -> assertArrayEquals(expects,numbers));
     }
 }

--- a/w07/test/gad/radixsort/RadixSortTest.java
+++ b/w07/test/gad/radixsort/RadixSortTest.java
@@ -1,0 +1,63 @@
+package gad.radixsort;
+
+import gad.radix.RadixSort;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RadixSortTest {
+
+    @ParameterizedTest
+    @MethodSource("provideMaxDecimalPlaces")
+    void testMaxDecimalPlaces(int[] elements, int expectedMax) {
+        assertEquals(expectedMax, RadixSort.getMaxDecimalPlaces(elements));
+    }
+
+    private static Stream<Arguments> provideMaxDecimalPlaces() {
+        return Stream.of(
+                Arguments.of(new int[]{1, 2, 5675, 222222, 930}, 6),
+                Arguments.of(new int[]{1, 2, 5675990, -222222, 930}, 7),
+                Arguments.of(new int[]{0, 0, 0, 0}, 1),
+                Arguments.of(new int[]{0, -1, 0, 0}, 1),
+                Arguments.of(new int[]{0, -889, 0, 0}, 3),
+                Arguments.of(new int[]{Integer.MAX_VALUE, Integer.MIN_VALUE, 0}, 10),
+                Arguments.of(new int[]{1, 2, 5675, -222222, 930, -1, 999999, 1000000}, 7)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideKey")
+    void testKey(int element, int decimalPlace, int expected) {
+        assertEquals(expected, RadixSort.key(element, decimalPlace));
+    }
+
+    private static Stream<Arguments> provideKey() {
+        return Stream.of(
+                Arguments.of(1234, 3, 1),
+                Arguments.of(981739, 2, 7),
+                Arguments.of(439183, 0, 3),
+                //Edge-Cases
+                Arguments.of(0, 99, 0),
+                Arguments.of(6, 0, 6),
+                Arguments.of(0, 0, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideKeyInvalidIndex")
+    void testKeyWithInvalidIndex(int element, int decimalPlace, int expected) {
+        assertEquals(expected, RadixSort.key(element, decimalPlace));
+    }
+
+    private static Stream<Arguments> provideKeyInvalidIndex() {
+        return Stream.of(
+                Arguments.of(12345, 5, 0),
+                Arguments.of(987654321, 10, 0),
+                Arguments.of(0, 0, 0)
+        );
+    }
+}

--- a/w07/test/gad/radixsort/RadixSortTest.java
+++ b/w07/test/gad/radixsort/RadixSortTest.java
@@ -40,8 +40,8 @@ public class RadixSortTest {
                 Arguments.of(1234, 3, 1),
                 Arguments.of(981739, 2, 7),
                 Arguments.of(439183, 0, 3),
-                //Edge-Cases
                 Arguments.of(0, 99, 0),
+                //Edge-Cases
                 Arguments.of(6, 0, 6),
                 Arguments.of(0, 0, 0)
         );

--- a/w07/test/gad/radixsort/StudentResultTest.java
+++ b/w07/test/gad/radixsort/StudentResultTest.java
@@ -1,0 +1,16 @@
+package gad.radixsort;
+
+import gad.radix.Result;
+
+public class StudentResultTest implements Result {
+    /**
+     *<div>
+     * This class and method exists only that during the tests on error is produced.
+     * It has the same structure as the StudentResult which is given in the code of Artemis,
+     * but without the "System.out.println(Arrays.toString(array));"
+     * which is for the sorting process irrelevant.
+     *</div>
+     */
+    @Override
+    public void logArray(int[] array) {}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I confirm that my tests, if any, are correct
    - [x] Optional: I pass **all** artemis tests.
    - [x] Optional: I pass **all** tests, that are added in this PR.
    - [x] Optional: I calculated manually the correct solutions on paper.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://github.com/JohannesStoehr/gad23-tests/blob/main/CONTRIBUTING.md).
- [x] The newly added tests do not reveal the solutions dynamically calculating the solutions as expected in the exercise.
- [x] Other students approved this Pull Request.

### Description
<!-- Describe your changes shortly -->
- `RadixSortTest`: I added two Edge-Casas for `provideKey` and in `provideKeyInvalidIndex` invalid Indices
- `BinaryRadixSortTest`: I added `sortOnlyNegativTest` which test if negativ numbers are sorted correcly only works if `lastSort` is implemented, `sortOnlyPositivTest` which test if positiv numbers are sorted correcly, `sortUsualTest` contains positiv and negativ Numbers, also `lastSort` must be implemented, that this test works and `sortBigTest` is the same as `sortUsualTest` but there are more numbers which should be sorted. This test could fail on some devices but is also repeated in the code.
